### PR TITLE
Fix release workflows on edit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   release:
-    types: [created, edited, prereleased, released]
+    types: [edited, published]
     branches:
       - main
 


### PR DESCRIPTION
edited and published seem to be the terminal cases for most release workflows, use those instead of created